### PR TITLE
Table names for seed! in sql/development should be keywords

### DIFF
--- a/src/sql/development.clj
+++ b/src/sql/development.clj
@@ -50,33 +50,33 @@
   (sql/query (get-jdbc-datasource) ["SELECT * FROM ACCOUNT"]))
 
 (defn new-account [id name email password salt iterations & {:as add-ons}]
-  ["account" (merge
-               {:id                  id
-                :name                name
-                :email               email
-                :active              true
-                :password_salt       salt
-                :password_iterations iterations
-                :password            (attr/encrypt password salt iterations)}
-               add-ons)])
+  [:account (merge
+              {:id                  id
+               :name                name
+               :email               email
+               :active              true
+               :password_salt       salt
+               :password_iterations iterations
+               :password            (attr/encrypt password salt iterations)}
+              add-ons)])
 
 (defn new-address [id street & {:as add-ons}]
-  ["address" (merge
-               {:id     id
-                :street street}
-               add-ons)])
+  [:address (merge
+              {:id     id
+               :street street}
+              add-ons)])
 
 (defn new-category [id label & {:as add-ons}]
-  ["category" (merge
-                {:id    id
-                 :label label}
-                add-ons)])
+  [:category (merge
+               {:id    id
+                :label label}
+               add-ons)])
 
 (defn new-item [id label price category-id]
-  ["item" {:id       id
-           :name     label
-           :price    price
-           :category category-id}])
+  [:item {:id       id
+          :name     label
+          :price    price
+          :category category-id}])
 
 (defn seed! []
   (let [db         (get-jdbc-datasource)


### PR DESCRIPTION
According to next.jdbc/1.0.409/next.jdbc-1.0.409.jar!/next/jdbc/specs.clj for `insert!`, the `table` must be a keyword but it is a string here:

https://github.com/fulcrologic/fulcro-rad-demo/blob/master/src/sql/development.clj#L53

Ref: https://github.com/seancorfield/next-jdbc/blob/v1.0.409/src/next/jdbc/specs.clj#L143