### PR TITLE
Move RAD demo onto datomic cloud

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-= Fulcro RAD Demo
+= Fulcro RAD Demo (Datomic Cloud Version)
 
 This is a demo repository for Fulcro RAD. It includes a shared source directory of files that would be
 common to any project, and then separate source directories that have specific files that would be

--- a/deps.edn
+++ b/deps.edn
@@ -39,9 +39,9 @@
                                      com.fulcrologic/fulcro-rad-sql {:mvn/version "0.0.2-alpha"}}}
 
            :datomic   {:extra-paths ["src/datomic" "src/datomic-tests"]
-                       :extra-deps  {com.datomic/datomic-free           {:mvn/version "0.9.5697" :exclusions [org.slf4j/slf4j-nop]}
-                                     com.datomic/dev-local              {:mvn/version "0.9.184"}
-                                     com.fulcrologic/fulcro-rad-datomic {:mvn/version "0.0.4-alpha"}}}
+                       :extra-deps  {com.datomic/dev-local              {:mvn/version "0.9.184"}
+                                     com.fulcrologic/fulcro-rad-datomic {:git/url "https://github.com/tylernisonoff/fulcro-rad-datomic"
+                                                                         :sha "3ec10e4d06a1980701e545843ebe20c50c97ad7b"}}}
            :run-tests {:main-opts  ["-m" "kaocha.runner"]
                        :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.629"}}}
 

--- a/deps.edn
+++ b/deps.edn
@@ -31,7 +31,8 @@
            org.clojure/clojure                    {:mvn/version "1.10.1"}}
 
  :aliases {:test      {:extra-paths ["src/shared-tests"]
-                       :extra-deps  {fulcrologic/fulcro-spec {:mvn/version "3.1.5"}}}
+                       :extra-deps  {fulcrologic/fulcro-spec {:mvn/version "3.1.5"}
+                                     dev-local-tu            {:mvn/version "0.1.0"}}}
 
            :sql       {:extra-paths ["src/sql" "src/sql-tests"]
                        :extra-deps  {com.h2database/h2              {:mvn/version "1.4.199" :exclusions [org.slf4j/slf4j-nop]}
@@ -39,6 +40,7 @@
 
            :datomic   {:extra-paths ["src/datomic" "src/datomic-tests"]
                        :extra-deps  {com.datomic/datomic-free           {:mvn/version "0.9.5697" :exclusions [org.slf4j/slf4j-nop]}
+                                     com.datomic/dev-local              {:mvn/version "0.9.184"}
                                      com.fulcrologic/fulcro-rad-datomic {:mvn/version "0.0.4-alpha"}}}
            :run-tests {:main-opts  ["-m" "kaocha.runner"]
                        :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.629"}}}

--- a/src/datomic-tests/com/example/model/authorization_test.clj
+++ b/src/datomic-tests/com/example/model/authorization_test.clj
@@ -1,41 +1,48 @@
 (ns com.example.model.authorization-test
   (:require
     [com.fulcrologic.rad.authorization :as auth]
-    [com.fulcrologic.rad.database-adapters.datomic :as datomic]
+    [com.fulcrologic.rad.database-adapters.datomic-cloud :as datomic]
     [com.fulcrologic.rad.ids :refer [new-uuid]]
     [com.example.model.seed :as seed]
     [com.example.model :refer [all-attributes]]
     [com.fulcrologic.guardrails.core :refer [>defn =>]]
     [com.example.model.authorization :as exauth]
-    [datomic.api :as d]
+    [dev-local-tu.core :as dev-local-tu]
+    [datomic.client.api :as d]
     [fulcro-spec.core :refer [specification assertions component]]))
 
 (specification "login!"
-  (let [c   (datomic/empty-db-connection all-attributes :production)
-        _   @(d/transact c [(seed/new-account (new-uuid 1) "tony" "tony@example.com" "letmein"
-                              :account/name "Tony")])
-        env (datomic/mock-resolver-env :production c)]
-    (component "Valid credentials"
-      (let [actual (exauth/login! env {:username "tony@example.com" :password "letmein"})]
-        (assertions
-          "Returns an auth success indicator"
-          (::auth/status actual) => :success
-          "Returns the auth provider's identity"
-          (::auth/provider actual) => :local
-          "Returns the account holder's first name"
-          (:account/name actual) => "Tony")))
-    (component "Bad username"
-      (let [actual (exauth/login! env {:username "tny@eample.com" :password "crap"})]
-        (assertions
-          "Returns an auth failure indicator"
-          (::auth/status actual) => :failed
-          "Returns the auth provider's identity"
-          (::auth/provider actual) => :local)))
-    (component "Invalid credentials"
-      (let [actual (exauth/login! env {:username "tony@example.com" :password "crap"})]
-        (assertions
-          "Returns an auth failure indicator"
-          (::auth/status actual) => :failed
-          "Returns the auth provider's identity"
-          (::auth/provider actual) => :local)))))
+  (with-open [db-env (dev-local-tu/test-env)]
+    (let [config {:datomic/env         :test
+                  :datomic/schema      :production
+                  :datomic/database    (str (gensym "test-database"))
+                  :datomic/test-client (:client db-env)}
+          c (datomic/start-database! all-attributes config {})
+          _   (d/transact c {:tx-data [(seed/new-account (new-uuid 1) "tony" "tony@example.com" "letmein"
+                                :account/name "Tony")]})
+          env (datomic/mock-resolver-env :production c)]
+
+      (component "Valid credentials"
+        (let [actual (exauth/login! env {:username "tony@example.com" :password "letmein"})]
+          (assertions
+            "Returns an auth success indicator"
+            (::auth/status actual) => :success
+            "Returns the auth provider's identity"
+            (::auth/provider actual) => :local
+            "Returns the account holder's first name"
+            (:account/name actual) => "Tony")))
+      (component "Bad username"
+        (let [actual (exauth/login! env {:username "tny@eample.com" :password "crap"})]
+          (assertions
+            "Returns an auth failure indicator"
+            (::auth/status actual) => :failed
+            "Returns the auth provider's identity"
+            (::auth/provider actual) => :local)))
+      (component "Invalid credentials"
+        (let [actual (exauth/login! env {:username "tony@example.com" :password "crap"})]
+          (assertions
+            "Returns an auth failure indicator"
+            (::auth/status actual) => :failed
+            "Returns the auth provider's identity"
+            (::auth/provider actual) => :local))))))
 

--- a/src/datomic/com/example/components/auto_resolvers.clj
+++ b/src/datomic/com/example/components/auto_resolvers.clj
@@ -3,7 +3,7 @@
     [com.example.model :refer [all-attributes]]
     [mount.core :refer [defstate]]
     [com.fulcrologic.rad.resolvers :as res]
-    [com.fulcrologic.rad.database-adapters.datomic :as datomic]
+    [com.fulcrologic.rad.database-adapters.datomic-cloud :as datomic]
     [taoensso.timbre :as log]))
 
 (defstate automatic-resolvers

--- a/src/datomic/com/example/components/database_queries.clj
+++ b/src/datomic/com/example/components/database_queries.clj
@@ -1,97 +1,108 @@
 (ns com.example.components.database-queries
   (:require
-    [com.fulcrologic.rad.database-adapters.datomic :as datomic]
-    [datomic.api :as d]
+    [com.fulcrologic.rad.database-adapters.datomic-cloud :as datomic]
+    [com.fulcrologic.rad.database-adapters.datomic-options :as do]
+    [datomic.client.api :as d]
     [taoensso.timbre :as log]
     [taoensso.encore :as enc]))
 
 (defn get-all-accounts
   [env query-params]
-  (if-let [db (some-> (get-in env [::datomic/databases :production]) deref)]
+  (if-let [db (some-> (get-in env [do/databases :production]) deref)]
     (let [ids (if (:show-inactive? query-params)
-                (d/q [:find '[?uuid ...]
-                      :where
-                      ['?dbid :account/id '?uuid]] db)
-                (d/q [:find '[?uuid ...]
-                      :where
-                      ['?dbid :account/active? true]
-                      ['?dbid :account/id '?uuid]] db))]
-      (mapv (fn [id] {:account/id id}) ids))
+                (d/q '[:find ?uuid
+                       :where
+                       [?dbid :account/id ?uuid]] db)
+                (d/q '[:find ?uuid
+                       :where
+                       [?dbid :account/active? true]
+                       [?dbid :account/id ?uuid]] db))]
+      (->> ids
+        flatten
+        (mapv (fn [id] {:account/id id}))))
     (log/error "No database atom for production schema!")))
 
 (defn get-all-items
   [env {:category/keys [id]}]
-  (if-let [db (some-> (get-in env [::datomic/databases :production]) deref)]
+  (if-let [db (some-> (get-in env [do/databases :production]) deref)]
     (let [ids (if id
-                (d/q '[:find [?uuid ...]
+                (d/q '[:find ?uuid
                        :in $ ?catid
                        :where
                        [?c :category/id ?catid]
                        [?i :item/category ?c]
                        [?i :item/id ?uuid]] db id)
-                (d/q '[:find [?uuid ...]
+                (d/q '[:find ?uuid
                        :where
                        [_ :item/id ?uuid]] db))]
-      (mapv (fn [id] {:item/id id}) ids))
+      (->> ids
+        flatten
+        (mapv (fn [id] {:item/id id}))))
     (log/error "No database atom for production schema!")))
 
 (defn get-customer-invoices [env {:account/keys [id]}]
-  (if-let [db (some-> (get-in env [::datomic/databases :production]) deref)]
-    (let [ids (d/q '[:find [?uuid ...]
+  (if-let [db (some-> (get-in env [do/databases :production]) deref)]
+    (let [ids (d/q '[:find ?uuid
                      :in $ ?cid
                      :where
                      [?dbid :invoice/id ?uuid]
                      [?dbid :invoice/customer ?c]
                      [?c :account/id ?cid]] db id)]
-      (mapv (fn [id] {:invoice/id id}) ids))
+      (->> ids
+        flatten
+        (mapv (fn [id] {:invoice/id id}))))
     (log/error "No database atom for production schema!")))
 
 (defn get-all-invoices
   [env query-params]
-  (if-let [db (some-> (get-in env [::datomic/databases :production]) deref)]
-    (let [ids (d/q [:find '[?uuid ...]
-                    :where
-                    ['?dbid :invoice/id '?uuid]] db)]
-      (mapv (fn [id] {:invoice/id id}) ids))
+  (if-let [db (some-> (get-in env [do/databases :production]) deref)]
+    (let [ids (d/q '[:find ?uuid
+                     :where
+                     [?dbid :invoice/id ?uuid]] db)]
+      (->> ids
+        flatten
+        (mapv (fn [id] {:invoice/id id}))))
     (log/error "No database atom for production schema!")))
 
 (defn get-invoice-customer-id
   [env invoice-id]
-  (if-let [db (some-> (get-in env [::datomic/databases :production]) deref)]
-    (d/q '[:find ?account-uuid .
-           :in $ ?invoice-uuid
-           :where
-           [?i :invoice/id ?invoice-uuid]
-           [?i :invoice/customer ?c]
-           [?c :account/id ?account-uuid]] db invoice-id)
+  (if-let [db (some-> (get-in env [do/databases :production]) deref)]
+    (let [ids (d/q '[:find ?account-uuid
+                     :in $ ?invoice-uuid
+                     :where
+                     [?i :invoice/id ?invoice-uuid]
+                     [?i :invoice/customer ?c]
+                     [?c :account/id ?account-uuid]] db invoice-id)]
+      (first (flatten ids)))
     (log/error "No database atom for production schema!")))
 
 (defn get-all-categories
   [env query-params]
-  (if-let [db (some-> (get-in env [::datomic/databases :production]) deref)]
-    (let [ids (d/q '[:find [?id ...]
+  (if-let [db (some-> (get-in env [do/databases :production]) deref)]
+    (let [ids (d/q '[:find ?id
                      :where
                      [?e :category/label]
                      [?e :category/id ?id]] db)]
-      (mapv (fn [id] {:category/id id}) ids))
+      (->> ids
+        flatten
+        (mapv (fn [id] {:category/id id}))))
     (log/error "No database atom for production schema!")))
 
 (defn get-line-item-category [env line-item-id]
-  (if-let [db (some-> (get-in env [::datomic/databases :production]) deref)]
-    (let [id (d/q '[:find ?cid .
-                    :in $ ?line-item-id
-                    :where
-                    [?e :line-item/id ?line-item-id]
-                    [?e :line-item/item ?item]
-                    [?item :item/category ?c]
-                    [?c :category/id ?cid]] db line-item-id)]
-      id)
+  (if-let [db (some-> (get-in env [do/databases :production]) deref)]
+    (first (d/q '[:find ?cid
+                  :in $ ?line-item-id
+                  :where
+                  [?e :line-item/id ?line-item-id]
+                  [?e :line-item/item ?item]
+                  [?item :item/category ?c]
+                  [?c :category/id ?cid]] db line-item-id))
     (log/error "No database atom for production schema!")))
 
 (defn get-login-info
   "Get the account name, time zone, and password info via a username (email)."
   [{::datomic/keys [databases] :as env} username]
-  (enc/if-let [db @(:production databases)]
+  (if-let [db (some-> (get-in env [do/databases :production]) deref)]
     (d/pull db [:account/name
                 {:time-zone/zone-id [:db/ident]}
                 :password/hashed-value

--- a/src/datomic/com/example/components/datomic.clj
+++ b/src/datomic/com/example/components/datomic.clj
@@ -1,6 +1,6 @@
 (ns com.example.components.datomic
   (:require
-    [com.fulcrologic.rad.database-adapters.datomic :as datomic]
+    [com.fulcrologic.rad.database-adapters.datomic-cloud :as datomic]
     [mount.core :refer [defstate]]
     [com.example.model :refer [all-attributes]]
     [com.example.components.config :refer [config]]))

--- a/src/datomic/com/example/components/delete_middleware.clj
+++ b/src/datomic/com/example/components/delete_middleware.clj
@@ -1,5 +1,5 @@
 (ns com.example.components.delete-middleware
   (:require
-    [com.fulcrologic.rad.database-adapters.datomic :as datomic]))
+    [com.fulcrologic.rad.database-adapters.datomic-cloud :as datomic]))
 
 (def middleware (datomic/wrap-datomic-delete))

--- a/src/datomic/com/example/components/parser.clj
+++ b/src/datomic/com/example/components/parser.clj
@@ -12,7 +12,7 @@
     [com.example.model.timezone :as timezone]
     [com.fulcrologic.rad.attributes :as attr]
     [com.fulcrologic.rad.blob :as blob]
-    [com.fulcrologic.rad.database-adapters.datomic :as datomic]
+    [com.fulcrologic.rad.database-adapters.datomic-cloud :as datomic]
     [com.fulcrologic.rad.form :as form]
     [com.fulcrologic.rad.pathom :as pathom]
     [mount.core :refer [defstate]]

--- a/src/datomic/com/example/components/save_middleware.clj
+++ b/src/datomic/com/example/components/save_middleware.clj
@@ -1,7 +1,7 @@
 (ns com.example.components.save-middleware
   (:require
     [com.fulcrologic.rad.middleware.save-middleware :as r.s.middleware]
-    [com.fulcrologic.rad.database-adapters.datomic :as datomic]
+    [com.fulcrologic.rad.database-adapters.datomic-cloud :as datomic]
     [com.example.components.datomic :refer [datomic-connections]]
     [com.fulcrologic.rad.blob :as blob]
     [com.example.model :as model]))

--- a/src/datomic/development.clj
+++ b/src/datomic/development.clj
@@ -10,15 +10,15 @@
     [com.example.model.account :as account]
     [com.example.model.address :as address]
     [com.fulcrologic.rad.ids :refer [new-uuid]]
-    [com.fulcrologic.rad.database-adapters.datomic :as datomic]
+    [com.fulcrologic.rad.database-adapters.datomic-cloud :as datomic]
     [com.fulcrologic.rad.resolvers :as res]
     [mount.core :as mount]
     [taoensso.timbre :as log]
-    [datomic.api :as d]
+    [datomic.client.api :as d]
     [com.fulcrologic.rad.attributes :as attr]
     [com.fulcrologic.rad.type-support.date-time :as dt]))
 
-(set-refresh-dirs "src/main" "src/datomic" "src/dev" "src/shared" "../fulcro-rad-datomic/src/main" "../fulcro-rad/src/main")
+(set-refresh-dirs "src/main" "src/datomic" "src/dev" "src/shared")
 
 (comment
   (let [db (d/db (:main datomic-connections))]
@@ -27,51 +27,51 @@
 (defn seed! []
   (dt/set-timezone! "America/Los_Angeles")
   (let [connection (:main datomic-connections)
-        date-1     (dt/html-datetime-string->inst "2020-01-01T12:00")
-        date-2     (dt/html-datetime-string->inst "2020-01-05T12:00")
-        date-3     (dt/html-datetime-string->inst "2020-02-01T12:00")
-        date-4     (dt/html-datetime-string->inst "2020-03-10T12:00")
-        date-5     (dt/html-datetime-string->inst "2020-03-21T12:00")]
+        date-1 (dt/html-datetime-string->inst "2020-01-01T12:00")
+        date-2 (dt/html-datetime-string->inst "2020-01-05T12:00")
+        date-3 (dt/html-datetime-string->inst "2020-02-01T12:00")
+        date-4 (dt/html-datetime-string->inst "2020-03-10T12:00")
+        date-5 (dt/html-datetime-string->inst "2020-03-21T12:00")]
     (when connection
       (log/info "SEEDING data.")
-      @(d/transact connection [(seed/new-address (new-uuid 1) "111 Main St.")
-                               (seed/new-account (new-uuid 100) "Tony" "tony@example.com" "letmein"
-                                 :account/addresses ["111 Main St."]
-                                 :account/primary-address (seed/new-address (new-uuid 300) "222 Other")
-                                 :time-zone/zone-id :time-zone.zone-id/America-Los_Angeles)
-                               (seed/new-account (new-uuid 101) "Sam" "sam@example.com" "letmein")
-                               (seed/new-account (new-uuid 102) "Sally" "sally@example.com" "letmein")
-                               (seed/new-account (new-uuid 103) "Barbara" "barb@example.com" "letmein")
-                               (seed/new-category (new-uuid 1000) "Tools")
-                               (seed/new-category (new-uuid 1002) "Toys")
-                               (seed/new-category (new-uuid 1003) "Misc")
-                               (seed/new-item (new-uuid 200) "Widget" 33.99
-                                 :item/category "Misc")
-                               (seed/new-item (new-uuid 201) "Screwdriver" 4.99
-                                 :item/category "Tools")
-                               (seed/new-item (new-uuid 202) "Wrench" 14.99
-                                 :item/category "Tools")
-                               (seed/new-item (new-uuid 203) "Hammer" 14.99
-                                 :item/category "Tools")
-                               (seed/new-item (new-uuid 204) "Doll" 4.99
-                                 :item/category "Toys")
-                               (seed/new-item (new-uuid 205) "Robot" 94.99
-                                 :item/category "Toys")
-                               (seed/new-item (new-uuid 206) "Building Blocks" 24.99
-                                 :item/category "Toys")
-                               (seed/new-invoice "invoice-1" date-1 "Tony"
-                                 [(seed/new-line-item "Doll" 1 5.0M)
-                                  (seed/new-line-item "Hammer" 1 14.99M)])
-                               (seed/new-invoice "invoice-2" date-2 "Sally"
-                                 [(seed/new-line-item "Wrench" 1 12.50M)
-                                  (seed/new-line-item "Widget" 2 32.0M)])
-                               (seed/new-invoice "invoice-3" date-3 "Sam"
-                                 [(seed/new-line-item "Wrench" 2 12.50M)
-                                  (seed/new-line-item "Hammer" 2 12.50M)])
-                               (seed/new-invoice "invoice-4" date-4 "Sally"
-                                 [(seed/new-line-item "Robot" 6 89.99M)])
-                               (seed/new-invoice "invoice-5" date-5 "Barbara"
-                                 [(seed/new-line-item "Building Blocks" 10 20.0M)])]))))
+      (d/transact connection {:tx-data [(seed/new-address (new-uuid 1) "111 Main St.")
+                                        (seed/new-account (new-uuid 100) "Tony" "tony@example.com" "letmein"
+                                          :account/addresses ["111 Main St."]
+                                          :account/primary-address (seed/new-address (new-uuid 300) "222 Other")
+                                          :time-zone/zone-id :time-zone.zone-id/America-Los_Angeles)
+                                        (seed/new-account (new-uuid 101) "Sam" "sam@example.com" "letmein")
+                                        (seed/new-account (new-uuid 102) "Sally" "sally@example.com" "letmein")
+                                        (seed/new-account (new-uuid 103) "Barbara" "barb@example.com" "letmein")
+                                        (seed/new-category (new-uuid 1000) "Tools")
+                                        (seed/new-category (new-uuid 1002) "Toys")
+                                        (seed/new-category (new-uuid 1003) "Misc")
+                                        (seed/new-item (new-uuid 200) "Widget" 33.99
+                                          :item/category "Misc")
+                                        (seed/new-item (new-uuid 201) "Screwdriver" 4.99
+                                          :item/category "Tools")
+                                        (seed/new-item (new-uuid 202) "Wrench" 14.99
+                                          :item/category "Tools")
+                                        (seed/new-item (new-uuid 203) "Hammer" 14.99
+                                          :item/category "Tools")
+                                        (seed/new-item (new-uuid 204) "Doll" 4.99
+                                          :item/category "Toys")
+                                        (seed/new-item (new-uuid 205) "Robot" 94.99
+                                          :item/category "Toys")
+                                        (seed/new-item (new-uuid 206) "Building Blocks" 24.99
+                                          :item/category "Toys")
+                                        (seed/new-invoice "invoice-1" date-1 "Tony"
+                                          [(seed/new-line-item "Doll" 1 5.0M)
+                                           (seed/new-line-item "Hammer" 1 14.99M)])
+                                        (seed/new-invoice "invoice-2" date-2 "Sally"
+                                          [(seed/new-line-item "Wrench" 1 12.50M)
+                                           (seed/new-line-item "Widget" 2 32.0M)])
+                                        (seed/new-invoice "invoice-3" date-3 "Sam"
+                                          [(seed/new-line-item "Wrench" 2 12.50M)
+                                           (seed/new-line-item "Hammer" 2 12.50M)])
+                                        (seed/new-invoice "invoice-4" date-4 "Sally"
+                                          [(seed/new-line-item "Robot" 6 89.99M)])
+                                        (seed/new-invoice "invoice-5" date-5 "Barbara"
+                                          [(seed/new-line-item "Building Blocks" 10 20.0M)])]}))))
 
 (defn start []
   (mount/start-with-args {:config "config/dev.edn"})

--- a/src/shared/config/defaults.edn
+++ b/src/shared/config/defaults.edn
@@ -2,9 +2,10 @@
                                      :host "localhost"}
 
  :com.fulcrologic.rad.database-adapters.datomic/databases
-                                    {:main {:datomic/schema           :production
-                                            :datomic/driver           :mem
-                                            :datomic/database         "example"
+                                    {:main {:datomic/schema :production
+                                            :datomic/database "example"
+                                            :datomic/client {:server-type :dev-local
+                                                             :system "fulcro-rad-demo"}
                                             :datomic/prevent-changes? true}}
 
  :com.fulcrologic.rad.database-adapters.sql/databases


### PR DESCRIPTION
This PR represents the changes needed to run the fulcro-rad-demo on datomic cloud. 

It includes:
* using the datomic-cloud database-adapter 
* moving onto the datomic client api (and fixing query / transaction syntax)
* updating default configuration