### PR TITLE
Remove refresh of ../fulcro-rad-datomic and ../fulcro-rad

### DIFF
--- a/src/datomic/development.clj
+++ b/src/datomic/development.clj
@@ -18,7 +18,7 @@
     [com.fulcrologic.rad.attributes :as attr]
     [com.fulcrologic.rad.type-support.date-time :as dt]))
 
-(set-refresh-dirs "src/main" "src/datomic" "src/dev" "src/shared" "../fulcro-rad-datomic/src/main" "../fulcro-rad/src/main")
+(set-refresh-dirs "src/main" "src/datomic" "src/dev" "src/shared")
 
 (comment
   (let [db (d/db (:main datomic-connections))]


### PR DESCRIPTION
With the upcoming changes add Datomic Cloud support to
`fulcro-rad-datomic`, this line will require users to have dependencies
for Datomic Cloud and on-prem on ones classpath. We could optionally
set up a deps alias that is meant to be used if you are developing
`fulcro-rad-datomic` with the demo, but this doesn't seem like something
that should necessarily be included in the public demo, so I'm proposing
removing it.

I removed the equivalent for `../fulcro-rad`, as it seems we should
either support both or none in this repo.

See https://github.com/fulcrologic/fulcro-rad-datomic/pull/9 for context 