### PR TITLE
Fix timezone input empty state

### DIFF
--- a/src/shared/com/example/model/timezone.cljc
+++ b/src/shared/com/example/model/timezone.cljc
@@ -612,13 +612,6 @@
    :WET                              "WET"
    :Zulu                             "Zulu"})
 
-(def us-zone-ids
-  (into #{}
-    (keep (fn [[k v]]
-            (when (str/starts-with? v "US/")
-              k)))
-    time-zones))
-
 (>defn namespaced-time-zone-labels
   "Returns a time zone map with all keys prefixed properly for Datomic enumerated names. `ns` should be something like
   \"account.timezone\"."
@@ -674,11 +667,11 @@
               datomic-time-zones))
 
           :else
-          (mapv (fn [zone-id]
+          (mapv (fn [[k v]]
                   (array-map
-                    :value zone-id
-                    :text (format-time-zone (get time-zones zone-id))))
-            us-zone-ids))})))
+                    :value k
+                    :text (format-time-zone v)))
+            time-zones))})))
 
 (def attributes [zone-id])
 #?(:clj

--- a/src/shared/com/example/model/timezone.cljc
+++ b/src/shared/com/example/model/timezone.cljc
@@ -612,7 +612,12 @@
    :WET                              "WET"
    :Zulu                             "Zulu"})
 
-(def us-zone-names (filterv #(str/starts-with? % "US/") (vals time-zones)))
+(def us-zone-ids
+  (into #{}
+    (keep (fn [[k v]]
+            (when (str/starts-with? v "US/")
+              k)))
+    time-zones))
 
 (>defn namespaced-time-zone-labels
   "Returns a time zone map with all keys prefixed properly for Datomic enumerated names. `ns` should be something like
@@ -647,6 +652,9 @@
                          :autocomplete/debounce-ms   100
                          :autocomplete/minimum-input 1}})
 
+(defn- format-time-zone [time-zone-name]
+  (str/replace time-zone-name "_" " "))
+
 #?(:clj
    (pc/defresolver all-time-zones [{:keys [query-params]} _]
      {::pc/output [{:autocomplete/time-zone-options [:text :value]}]}
@@ -654,19 +662,23 @@
        {:autocomplete/time-zone-options
         (cond
           (keyword? only)
-          [{:text (str/replace (name only) "_" " ") :value only}]
+          [{:text (format-time-zone (name only)) :value only}]
 
           (seq search-string)
           (let [search-string (str/lower-case search-string)]
             (into []
               (comp
-                (map (fn [[k v]] (array-map :text (str/replace v "_" " ") :value k)))
+                (map (fn [[k v]] (array-map :text (format-time-zone v) :value k)))
                 (filter (fn [{:keys [text]}] (str/includes? (str/lower-case text) search-string)))
                 (take 10))
               datomic-time-zones))
 
           :else
-          us-zone-names)})))
+          (mapv (fn [zone-id]
+                  (array-map
+                    :value zone-id
+                    :text (format-time-zone (get time-zones zone-id))))
+            us-zone-ids))})))
 
 (def attributes [zone-id])
 #?(:clj


### PR DESCRIPTION
The time zone input is broken when you add text to the input, then delete it. This is because the resolver returns a vector of strings in this case rather than a vector of maps with `:text` and `:value` keys. This PR fixes the shape of the output to match expectations.

Happy to make whatever changes to this PR would make this more convenient to review and manage.