### PR TITLE
Add index resolver for Inspect's Ind. Expl.

### DIFF
--- a/src/datomic/com/example/components/parser.clj
+++ b/src/datomic/com/example/components/parser.clj
@@ -19,7 +19,16 @@
     [com.example.model.sales :as sales]
     [com.example.model.item :as item]
     [com.wsscode.pathom.core :as p]
-    [com.fulcrologic.rad.type-support.date-time :as dt]))
+    [com.fulcrologic.rad.type-support.date-time :as dt]
+    [com.wsscode.pathom.connect :as pc]))
+
+(pc/defresolver index-explorer [{::pc/keys [indexes]} _]
+                {::pc/input  #{:com.wsscode.pathom.viz.index-explorer/id}
+                 ::pc/output [:com.wsscode.pathom.viz.index-explorer/index]}
+                {:com.wsscode.pathom.viz.index-explorer/index
+                 (p/transduce-maps
+                   (remove (comp #{::pc/resolve ::pc/mutate} key))
+                   indexes)})
 
 (defstate parser
   :start
@@ -44,4 +53,5 @@
      invoice/resolvers
      item/resolvers
      sales/resolvers
-     timezone/resolvers]))
+     timezone/resolvers
+     index-explorer]))

--- a/src/sql/com/example/components/parser.clj
+++ b/src/sql/com/example/components/parser.clj
@@ -15,7 +15,16 @@
     [com.example.model.account :as account]
     [com.example.model.timezone :as timezone]
     [com.fulcrologic.rad.attributes :as rad.attr]
-    [com.example.model.invoice :as invoice]))
+    [com.example.model.invoice :as invoice]
+    [com.wsscode.pathom.connect :as pc]))
+
+(pc/defresolver index-explorer [{::pc/keys [indexes]} _]
+  {::pc/input  #{:com.wsscode.pathom.viz.index-explorer/id}
+   ::pc/output [:com.wsscode.pathom.viz.index-explorer/index]}
+  {:com.wsscode.pathom.viz.index-explorer/index
+   (p/transduce-maps
+     (remove (comp #{::pc/resolve ::pc/mutate} key))
+     indexes)})
 
 (defstate parser
   :start
@@ -30,4 +39,5 @@
      (blob/resolvers all-attributes)
      account/resolvers
      invoice/resolvers
-     timezone/resolvers]))
+     timezone/resolvers
+     index-explorer]))


### PR DESCRIPTION
Add the necessary resolver, filtering out values not supported
by transit (resolver functions, mutations), so that Load indexes
in the Index Explorer of Fulcro Inspect will work.