### PR TITLE
Add mock-resolver-env as troubleshooting convenience

### DIFF
--- a/src/datomic/development.clj
+++ b/src/datomic/development.clj
@@ -95,7 +95,7 @@
 
 (defn mock-resolver-env
   "An env including the DB to pass to a resolver when calling it manually.
-  BEWARE: You must start fulcro first before you can use this.
+  BEWARE: You must call `(start)` first before you can use this.
 
   Example:
 

--- a/src/datomic/development.clj
+++ b/src/datomic/development.clj
@@ -93,3 +93,17 @@
 
 (def reset #'restart)
 
+(defn mock-resolver-env
+  "An env including the DB to pass to a resolver when calling it manually.
+  BEWARE: You must start fulcro first before you can use this.
+
+  Example:
+
+  ```
+  ((:com.wsscode.pathom.connect/resolve com.example.model.account/all-accounts)
+    (mock-resolver-env) {})
+  ; => #:account{:all-accounts [...]}
+  ```"
+  []
+  {::datomic/databases
+   {:production (atom (d/db (:main datomic-connections)))}})

--- a/src/sql/development.clj
+++ b/src/sql/development.clj
@@ -136,6 +136,21 @@
 
 (def reset #'restart)
 
+(defn mock-resolver-env
+  "An env including the DB to pass to a resolver when calling it manually.
+  BEWARE: You must start fulcro first before you can use this.
+
+  Example:
+
+  ```
+  ((:com.wsscode.pathom.connect/resolve com.example.model.account/all-accounts)
+    (mock-resolver-env) {})
+  ; => #:account{:all-accounts [...]}
+  ```"
+  []
+  {::rad.sql/connection-pools
+   {:production (:main pools/connection-pools)}})
+
 (comment
   (let [db {:dbtype   "postgresql"
             :dbname   "example"

--- a/src/sql/development.clj
+++ b/src/sql/development.clj
@@ -110,8 +110,8 @@
         (let [[table entity] row]
           (sql/insert! db table entity))
         (catch Exception e
-          (log/error e row))))
-    ))
+          (log/error e row))))))
+
 
 (comment
   (seed!))
@@ -138,7 +138,7 @@
 
 (defn mock-resolver-env
   "An env including the DB to pass to a resolver when calling it manually.
-  BEWARE: You must start fulcro first before you can use this.
+  BEWARE: You must call `(start)` first before you can use this.
 
   Example:
 
@@ -170,5 +170,5 @@
 
   (rad.sql/column-names account/attributes [::account/id ::account/active?])
 
-  (contains? #{::account/name} (::attr/qualified-key account/name))
-  )
+  (contains? #{::account/name} (::attr/qualified-key account/name)))
+


### PR DESCRIPTION
 It is sometimes useful to be able to run a resolver from the REPL to troubleshoot problems with it.
 But people struggle to find out how to construct the environment to be able to run it. This will help them.