### PR TITLE
Update crux deps to 1.18.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -42,10 +42,10 @@
                        :extra-deps  {com.datomic/datomic-free           {:mvn/version "0.9.5697" :exclusions [org.slf4j/slf4j-nop]}
                                      com.fulcrologic/fulcro-rad-datomic {:mvn/version "1.0.9"}}}
            :crux      {:extra-paths ["src/crux" "src/crux-tests"]
-                       :extra-deps {juxt/crux-core           {:mvn/version "21.02-1.15.0-beta"}
-                                    juxt/crux-rocksdb        {:mvn/version "21.02-1.15.0-beta"}
-                                    juxt/crux-jdbc           {:mvn/version "21.02-1.15.0-beta"}
-                                    roterski/fulcro-rad-crux {:mvn/version "0.0.1-alpha-1"}}}
+                       :extra-deps {pro.juxt.crux/crux-core    {:mvn/version "1.18.0"}
+                                    pro.juxt.crux/crux-rocksdb {:mvn/version "1.18.0"}
+                                    pro.juxt.crux/crux-jdbc    {:mvn/version "1.18.0"}
+                                    roterski/fulcro-rad-crux   {:mvn/version "0.0.1-alpha-3"}}}
            :run-tests {:main-opts  ["-m" "kaocha.runner"]
                        :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.732"}}}
 

--- a/src/crux/com/example/components/database_queries.clj
+++ b/src/crux/com/example/components/database_queries.clj
@@ -94,7 +94,7 @@
   [env username]
   (enc/if-let [db (some-> (get-in env [co/databases :production]) deref)]
     (-> db
-        (crux/q '{:find [(eql/project ?account [:account/name
+        (crux/q '{:find [(pull ?account [:account/name
                                                 {:time-zone/zone-id [:db/ident]}
                                                 :password/hashed-value
                                                 :password/salt


### PR DESCRIPTION
This PR:
- bumps [crux](https://github.com/juxt/crux) to `1.18.0`,
- bumps [fulcro-rad-crux](https://github.com/roterski/fulcro-rad-crux) to `0.0.1-alpha-3`,
- adjusts for the [crux's breaking change of deprecating `eql/project` in favour of `pull`](https://github.com/juxt/crux/releases/tag/21.04-1.16.0).

### Testing
I've clicked through the demo app and my other project using both of those deps and ran tests - no issue was found.