### PR TITLE
config/defaults.edn remove :ip constraint to allow demo to work on wsl2

### DIFF
--- a/src/shared/config/defaults.edn
+++ b/src/shared/config/defaults.edn
@@ -1,5 +1,4 @@
-{:org.httpkit.server/config         {:port 3000
-                                     :ip   "localhost"}
+{:org.httpkit.server/config         {:port 3000 }
 
  :com.fulcrologic.rad.database-adapters.datomic/databases
                                     {:main {:datomic/schema           :production


### PR DESCRIPTION
On WSL2 on Windows 10, could start and connect to the shadow-cljs ui from the windows host (on http://localhost:9630/), but could  not get to the demo app on (http://localhost:3000). 
On WSL2 the Linux machine is an almost but not quite VM running on hypervisor, and it's IP is different to the windows host, using a network bridge, so restricting to 'localhost' means the host will be rejected. 
This PR removes that constraint so the demo should 'just work' for  more people