### PR TITLE
Fix xtdb-nodes :stop handler

### DIFF
--- a/src/xtdb/com/example/components/xtdb.clj
+++ b/src/xtdb/com/example/components/xtdb.clj
@@ -8,5 +8,5 @@
   :start
   (xtdb/start-databases (xtdb/symbolize-xtdb-modules config))
   :stop
-  (for [node xtdb-nodes]
+  (doseq [[_ node] xtdb-nodes]
     (.close node)))


### PR DESCRIPTION
Kudos to sheluchin [for reporting it](https://clojurians.slack.com/archives/C68M60S4F/p1637001322267800). 🙌 

There were actually two issues:
- `for` is lazy executed so this handler wouldn't be called here at all,
- `xtdb-nodes` is a map `{:dbname node}` so the iterated value in the loop is a `[dbname node]` pair, not just `node`.