### PR TITLE
Use xtdb/wrap-env from plugin library

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -45,7 +45,7 @@
                        :extra-deps  {com.xtdb/xtdb-core                   {:mvn/version "1.19.0"}
                                      com.xtdb/xtdb-rocksdb                {:mvn/version "1.19.0"}
                                      com.xtdb/xtdb-jdbc                   {:mvn/version "1.19.0"}
-                                     net.clojars.roterski/fulcro-rad-xtdb {:mvn/version "0.0.1-alpha-7"}}}
+                                     net.clojars.roterski/fulcro-rad-xtdb {:mvn/version "0.0.1-alpha-8"}}}
            :run-tests {:main-opts  ["-m" "kaocha.runner"]
                        :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.732"}}}
 

--- a/src/xtdb/com/example/components/parser.clj
+++ b/src/xtdb/com/example/components/parser.clj
@@ -17,31 +17,15 @@
     [com.fulcrologic.rad.form :as form]
     [com.fulcrologic.rad.pathom3 :as pathom3]
     [mount.core :refer [defstate]]
-    [roterski.fulcro.rad.database-adapters.xtdb :as xtdb]
-    [roterski.fulcro.rad.database-adapters.xtdb-options :as xo]
-    [taoensso.encore :as enc]
-    [xtdb.api :as xt]))
-
-;; TASK: This should move to the library
-(defn xtdb-wrap-env
-  ([database-adapter]
-   (xtdb-wrap-env nil database-adapter))
-  ([base-wrapper database-mapper]
-   (fn [env]
-     (let [database-node-map (database-mapper env)
-           databases         (enc/map-vals (fn [v] (atom (xt/db v))) database-node-map)]
-       (cond-> (assoc env
-                 xo/nodes database-node-map
-                 xo/databases databases)
-         base-wrapper (base-wrapper))))))
+    [roterski.fulcro.rad.database-adapters.xtdb :as xtdb]))
 
 (defstate parser
   :start
   (let [env-middleware (-> (attr/wrap-env all-attributes)
-                         (form/wrap-env save/middleware delete/middleware)
-                         (xtdb-wrap-env (fn [_] {:production (:main xtdb-nodes)}))
-                         (blob/wrap-env bs/temporary-blob-store {:files         bs/file-blob-store
-                                                                 :avatar-images bs/image-blob-store}))]
+                           (form/wrap-env save/middleware delete/middleware)
+                           (xtdb/wrap-env (fn [_] {:production (:main xtdb-nodes)}))
+                           (blob/wrap-env bs/temporary-blob-store {:files         bs/file-blob-store
+                                                                   :avatar-images bs/image-blob-store}))]
     (pathom3/new-processor config env-middleware []
       [automatic-resolvers
        form/resolvers


### PR DESCRIPTION
This PR replaces inline `xtdb-wrap-env` with `xtdb/wrap-env` of `fulcro-rad-xtdb` library that has been updated with removal of direct pathom dependency.

To ensure compatibility across different pathom & plugins versions I added a fairly simple eql test that could be run against different backends.

I put those tests on two separate branches:
- branching off `develop` https://github.com/fulcrologic/fulcro-rad-demo/compare/develop...roterski:add-eql-shared-tests
- rebased to `pathom3` branch https://github.com/fulcrologic/fulcro-rad-demo/compare/pathom3...roterski:add-eql-shared-tests-p3 (let me know if you want me to open it as PR)

The idea is that you can run those tests with `clj -A:dev:xtdb:test:run-tests` or `clj -A:dev:datomic:test:run-tests` and you should expect the same results, using different backends.

The tests are also useful for ensuring that nothing broke during the pathom2->pathom3 migration as they should pass on the [rebased branch]( https://github.com/roterski/fulcro-rad-demo/tree/add-eql-shared-tests-p3) as well. This is almost the case but there's one thing that makes those tests fail indicating migration bug:
- [this line adding `:tempids` to query](https://github.com/roterski/fulcro-rad-demo/blob/add-eql-shared-tests-p3/src/shared-tests/eql_tests/account_test.clj#L76) was needed for tests to pass
- without it, `:tempids` are not returned in the response, breaking a few fulcro-rad features and assumptions
- in pathom2 rad wrapper `com.fulcrologic.rad.pathom`, `:tempids` was added globally via [`::pc/mutation-join-globals`](https://github.com/fulcrologic/fulcro-rad/blob/develop/src/main/com/fulcrologic/rad/pathom.clj#L130)
- `com.fulcrologic.rad.pathom3` does not add `:tempids` to queries breaking pathom2/3 integrations compatibility and eql-tests.
- However, pathom3 no longer supports pathom2's `::pc/mutation-join-globals` option so some other equivalent needs to be found.