### PR TITLE
Fix tags for all other DBs than Datomic

### DIFF
--- a/src/asami/com/example/components/database_queries.clj
+++ b/src/asami/com/example/components/database_queries.clj
@@ -19,6 +19,12 @@
       (mapv (fn [id] {:account/id id}) ids))
     (log/error "No database atom for production schema!")))
 
+(defn get-all-tags
+  [env _]
+  (let [db (doto (some-> (get-in env [::asami/databases :production]) deref) assert)
+        ids (d/q '[:find ?uuid :where [?dbid :tag/id ?uuid]] db)]
+       (mapv (fn [[id]] {:tag/id id}) ids)))
+
 (defn get-all-items
   [env {:category/keys [id]}]
   (if-let [db (some-> (get-in env [::asami/databases :production]) deref)]

--- a/src/asami/development.clj
+++ b/src/asami/development.clj
@@ -29,7 +29,9 @@
 (defn delete-db!
   "Delete the DB. BEWARE: This invalidates `com.example.components.asami/asami-connections` and thus requires a restart."
   []
-  (d/delete-database (asami.conn/config->url (-> com.example.components.config/config ::asami/databases :main))))
+  (d/delete-database (asami.conn/config->url (-> com.example.components.config/config ::asami/databases :main)))
+  ;; As of Asami 2.3.2 the connections atom is not cleared when a DB is closed/deleted => do it manually
+  (reset! d/connections nil))
 
 (defn- add-asami-id [entity]
   (let [[id-prop & more] (->> (keys entity) (filter #(and (= "id" (name %)) (namespace %))))

--- a/src/shared/config/defaults.edn
+++ b/src/shared/config/defaults.edn
@@ -42,7 +42,7 @@
          :hikaricp/config          {"dataSourceClassName" "org.h2.jdbcx.JdbcDataSource"
                                     "dataSource.user"     "sa"
                                     "dataSource.password" "sa"
-                                    "dataSource.URL"      "jdbc:h2:mem:dev-db"}
+                                    "dataSource.URL"      "jdbc:h2:mem:dev-db;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH"}
          :sql/vendor               :h2
          :sql/auto-create-missing? true
          :sql/schema               :production}}

--- a/src/sql/com/example/components/database_queries.clj
+++ b/src/sql/com/example/components/database_queries.clj
@@ -15,6 +15,13 @@
         rows           (mapv #(hash-map :account/id (:id %)) (jdbc/query data-source [sql] {:builder-fn query/row-builder}))]
     rows))
 
+(defn get-all-tags
+  [env _]
+  (let [data-source  (get-in env [::sql/connection-pools :production])
+        query-params ["SELECT id FROM tag"]
+        rows         (mapv #(hash-map :tag/id (:id %)) (jdbc/query data-source query-params {:builder-fn query/row-builder}))]
+       rows))
+
 (defn get-all-items
   [env {:category/keys [id]}]
   (let [data-source  (get-in env [::sql/connection-pools :production])

--- a/src/sql/development.clj
+++ b/src/sql/development.clj
@@ -40,6 +40,10 @@
     (jdbc/execute! (get-jdbc-datasource) [stmt]))
 
   (sql/query (get-jdbc-datasource) ["show tables"])
+  (sql/query (get-jdbc-datasource) ["show columns from item"])
+  (sql/query (get-jdbc-datasource) ["select * from INFORMATION_SCHEMA.TABLE_CONSTRAINTS"])
+  (sql/query (get-jdbc-datasource) ["select i.*, ic.COLUMN_NAME from INFORMATION_SCHEMA.INDEXES i JOIN INFORMATION_SCHEMA.INDEX_COLUMNS ic on i.INDEX_NAME=ic.INDEX_NAME where i.table_name='item'"])
+  (jdbc/execute! (get-jdbc-datasource) ["CREATE SEQUENCE account_id_seq;"])
   (jdbc/execute! (get-jdbc-datasource) ["CREATE SEQUENCE account_id_seq;"])
   (jdbc/execute! (get-jdbc-datasource) ["SELECT NEXTVAL('account_id_seq') AS id"])
   (sql/query (get-jdbc-datasource) ["show columns from address"])

--- a/src/xtdb/com/example/components/database_queries.clj
+++ b/src/xtdb/com/example/components/database_queries.clj
@@ -18,6 +18,13 @@
          (mapv (fn [[id]] {:account/id id})))
     (log/error "No database atom for production schema!")))
 
+(defn get-all-tags
+      [env _]
+      (let [db (doto @(get-in env [xo/databases :production]) assert)
+            ids (xt/q db '{:find [?uuid]
+                           :where [[_ :tag/id ?uuid]]})]
+           (mapv (fn [[id]] {:tag/id id}) ids)))
+
 (defn get-all-items
   [env {:category/keys [id]}]
   (if-let [db (some-> (get-in env [xo/databases :production]) deref)]


### PR DESCRIPTION
* Add the newly introduced get-all-tags to all other databases (Datomic already had it)
* Turn on Postgres compatibility on H2 (not tested)
* Un-break Asami when delete-database! is called

Beware: H2 does not work without fulcrologic/fulcro-rad-sql#18