### PR TITLE
use datomic local

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -71,15 +71,7 @@ if you don't have `yarn`, use `npm install` instead.
 
 == Using Datomic Cloud
 
-The Datomic database used in the demo is Datomic Cloud. On-prem is also supported (using a different namespace. See
-the `on-prem` tag which uses older versions the datomic RAD plugin and Datomic free), but
-the datomic-free version does not have enough features to support RAD. Datomic Cloud has a dev-local driver that can
-be used to create in-memory database, which makes writing an easy-to-run demo more simple.
-
-You will need to obtain the current version of dev-local from https://cognitect.com/dev-tools[Cognitect] in order to
-run this demo (and update the `deps.edn` to reflect the version you got).
-
-Once you have the dependencies you should be able to start the webapp in Datomic mode using:
+The Datomic database used in the demo is Datomic Local. It uses an in-memory database, which makes writing an easy-to-run demo simple. To start the webapp in Datomic, use:
 
 [source, bash]
 -----

--- a/deps.edn
+++ b/deps.edn
@@ -38,8 +38,7 @@
                                      com.fulcrologic/fulcro-rad-sql {:mvn/version "0.0.8-alpha"}}}
 
            :datomic   {:extra-paths ["src/datomic"]
-                       :extra-deps  {com.datomic/dev-local              {:mvn/version "1.0.243"}
-                                     com.datomic/client-cloud           {:mvn/version "1.0.123"}
+                       :extra-deps  {com.datomic/local                  {:mvn/version "1.0.267"}
                                      com.fulcrologic/fulcro-rad-datomic {:mvn/version "1.4.5"}}}
            :asami     {:extra-paths ["src/asami" "src/asami-tests"]
                        :extra-deps  {cz.holyjak/fulcro-rad-asami {:git/url "https://github.com/holyjak/fulcro-rad-asami"


### PR DESCRIPTION
It looks like the newly release [datomic local](https://blog.datomic.com/2023/08/datomic-local-is-released.html) is sufficient to run the demo and requires no user intervention to download other libraries. I'm not an expert in fulcro RAD or Datomic, so I could be missing something, but the demo seems fully functional to me.

